### PR TITLE
fix: utilize yargs parseSync for cli parsing inside a constructor

### DIFF
--- a/src/AppArguments.ts
+++ b/src/AppArguments.ts
@@ -16,14 +16,7 @@ export class AppArguments {
       type: 'string',
     }));
 
-    // Appears that the y.argv may 'sometimes' be a Promise, it's unclear
-    // currently when this is might be, and if it's a problem for the application.
-    // See issue on this topic: https://github.com/yargs/yargs/issues/2175
-    // TODO: Address issue accordingly to response, e.g.:
-    // 1. Utilize yargs parsing in a synchronous way (if possible)
-    // 2. Or move the yargs parsing via an async getter function
-    const argv = y.argv as any;
-
+    const argv = y.parseSync();
     this.args = this.args.map((arg) => ({
       ...arg,
       value: argv[arg.shortName] as string,


### PR DESCRIPTION
Closes: https://github.com/antwika/app/issues/15